### PR TITLE
feat(cd): configure Nginx self-configuration and automated reload

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -90,6 +90,16 @@ jobs:
             ${{ secrets.DOCKER_HUB_USERNAME }}/ds-vendas:latest
             ${{ secrets.DOCKER_HUB_USERNAME }}/ds-vendas:sha-${{ steps.vars.outputs.short_sha }}
 
+      - name: Copy Nginx config via SCP
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USERNAME }}
+          key: ${{ secrets.SSH_KEY }}
+          source: "nginx/dsvendas.conf"
+          target: "/tmp"
+          strip_components: 1
+
       - name: Remotely Deploy to Cloud VM
         uses: appleboy/ssh-action@v1.0.3
         with:
@@ -159,3 +169,7 @@ jobs:
             
             # Prune unused images and containers (removes the old image version)
             docker image prune -a -f
+            
+            # Move Nginx config and reload Nginx
+            sudo mv /tmp/dsvendas.conf /etc/nginx/conf.d/dsvendas.conf
+            sudo nginx -t && sudo nginx -s reload

--- a/nginx/dsvendas.conf
+++ b/nginx/dsvendas.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name dsvendas-homolog.felipeschirmann.dev.br;
+    # Redirect HTTP to HTTPS
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl http2;
+    server_name dsvendas-homolog.felipeschirmann.dev.br;
+
+    ssl_certificate /etc/nginx/ssl/felipeschirmann.dev.br.pem;
+    ssl_certificate_key /etc/nginx/ssl/felipeschirmann.dev.br.key;
+
+    # SSL Configs
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+
+    location / {
+        proxy_pass http://127.0.0.1:8180; # Port where Spring Boot runs in Docker for DSVendas
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
This PR introduces automated Nginx reverse proxy configuration. It adds the Nginx server block under nginx/dsvendas.conf, copies it via SCP to the target VM, and reloads Nginx on the SSH deploy script.