### PR TITLE
fix(controller): handle invalid sorting properties globally and sanitize Swagger default sort

### DIFF
--- a/backend/src/main/java/com/devsuperior/dsvendas/controllers/SaleController.java
+++ b/backend/src/main/java/com/devsuperior/dsvendas/controllers/SaleController.java
@@ -23,6 +23,17 @@ public class SaleController {
 	
 	@GetMapping
 	public ResponseEntity <Page <SaleDTO>> findAll(Pageable pageable){
+		if (pageable.getSort().isSorted()) {
+			boolean hasInvalidSort = pageable.getSort().stream()
+					.anyMatch(order -> "string".equalsIgnoreCase(order.getProperty()));
+			if (hasInvalidSort) {
+				pageable = org.springframework.data.domain.PageRequest.of(
+						pageable.getPageNumber(),
+						pageable.getPageSize(),
+						org.springframework.data.domain.Sort.unsorted()
+				);
+			}
+		}
 		Page<SaleDTO> list = service.findAll(pageable);
 		return ResponseEntity.ok(list);
 	}

--- a/backend/src/main/java/com/devsuperior/dsvendas/controllers/exceptions/ControllerExceptionHandler.java
+++ b/backend/src/main/java/com/devsuperior/dsvendas/controllers/exceptions/ControllerExceptionHandler.java
@@ -1,0 +1,27 @@
+package com.devsuperior.dsvendas.controllers.exceptions;
+
+import java.time.Instant;
+
+import org.springframework.data.mapping.PropertyReferenceException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@ControllerAdvice
+public class ControllerExceptionHandler {
+
+    @ExceptionHandler(PropertyReferenceException.class)
+    public ResponseEntity<StandardError> propertyReference(PropertyReferenceException e, HttpServletRequest request) {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        StandardError err = new StandardError();
+        err.setTimestamp(Instant.now());
+        err.setStatus(status.value());
+        err.setError("Invalid sorting property");
+        err.setMessage(e.getMessage());
+        err.setPath(request.getRequestURI());
+        return ResponseEntity.status(status).body(err);
+    }
+}

--- a/backend/src/main/java/com/devsuperior/dsvendas/controllers/exceptions/StandardError.java
+++ b/backend/src/main/java/com/devsuperior/dsvendas/controllers/exceptions/StandardError.java
@@ -1,0 +1,57 @@
+package com.devsuperior.dsvendas.controllers.exceptions;
+
+import java.io.Serializable;
+import java.time.Instant;
+
+public class StandardError implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private Instant timestamp;
+    private Integer status;
+    private String error;
+    private String message;
+    private String path;
+
+    public StandardError() {
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public Integer getStatus() {
+        return status;
+    }
+
+    public void setStatus(Integer status) {
+        this.status = status;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+    public void setError(String error) {
+        this.error = error;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public void setPath(String path) {
+        this.path = path;
+    }
+}

--- a/backend/src/test/java/com/devsuperior/dsvendas/controllers/SaleControllerIT.java
+++ b/backend/src/test/java/com/devsuperior/dsvendas/controllers/SaleControllerIT.java
@@ -44,4 +44,22 @@ public class SaleControllerIT {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$").isArray());
     }
+
+    @Test
+    public void findAllWithInvalidSwaggerSortShouldReturnUnsortedPage() throws Exception {
+        mockMvc.perform(get("/sales?page=0&size=20&sort=string")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").exists())
+                .andExpect(jsonPath("$.content").isArray());
+    }
+
+    @Test
+    public void findAllWithInvalidSortPropertyShouldReturnBadRequest() throws Exception {
+        mockMvc.perform(get("/sales?page=0&size=20&sort=invalidField")
+                .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Invalid sorting property"))
+                .andExpect(jsonPath("$.message").exists());
+    }
 }


### PR DESCRIPTION
This PR resolves HTTP 500 errors when sorting by invalid fields (like the default 'string' placeholder in Swagger UI). It introduces a global ControllerExceptionHandler to return 400 Bad Request on PropertyReferenceException, and sanitizes 'string' sort requests in SaleController.