### PR TITLE
perf(frontend): lazy-load Dashboard page using React.lazy to optimize bundle size

### DIFF
--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -1,18 +1,28 @@
-import Dashboard from "pages/Dashboard";
+import React, { lazy, Suspense } from "react";
 import Home from "pages/Home";
 import { BrowserRouter, Route, Switch } from "react-router-dom";
+
+const Dashboard = lazy(() => import("pages/Dashboard"));
 
 const Routes = () => {
     return (
         <BrowserRouter>
-            <Switch>
-                <Route path="/" exact>
-                    <Home/>
-                </Route>
-                <Route path="/dashboard" >
-                    <Dashboard/>
-                </Route>
-            </Switch>
+            <Suspense fallback={
+                <div className="d-flex align-items-center justify-content-center" style={{ height: "100vh" }}>
+                    <div className="spinner-border text-primary" role="status">
+                        <span className="visually-hidden">Loading...</span>
+                    </div>
+                </div>
+            }>
+                <Switch>
+                    <Route path="/" exact>
+                        <Home/>
+                    </Route>
+                    <Route path="/dashboard" >
+                        <Dashboard/>
+                    </Route>
+                </Switch>
+            </Suspense>
         </BrowserRouter>
     );
   };


### PR DESCRIPTION
This pull request adds code splitting to the frontend by lazy-loading the Dashboard page, reducing the initial load size.