### PR TITLE
fix: CD checkout depth and SecurityConfig ReDoS

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          fetch-depth: 0
 
       - name: Detect Changes
         uses: dorny/paths-filter@v3

--- a/backend/src/main/java/com/devsuperior/dsvendas/config/SecurityConfig.java
+++ b/backend/src/main/java/com/devsuperior/dsvendas/config/SecurityConfig.java
@@ -56,7 +56,11 @@ public class SecurityConfig {
 		CorsConfiguration configuration = new CorsConfiguration();
 		String allowedOrigins = env.getProperty("cors.allow.frontend");
 		if (allowedOrigins != null) {
-			configuration.setAllowedOrigins(Arrays.asList(allowedOrigins.split("\\s*,\\s*")));
+			String[] originsArray = allowedOrigins.split(",");
+			for (int i = 0; i < originsArray.length; i++) {
+				originsArray[i] = originsArray[i].trim();
+			}
+			configuration.setAllowedOrigins(Arrays.asList(originsArray));
 		}
 		configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
 		configuration.setAllowedHeaders(Arrays.asList("Content-Type", "Authorization"));


### PR DESCRIPTION
This PR addresses: 1. CD pipeline failure by introducing fetch-depth: 0 in checkout step inside .github/workflows/cd.yml. 2. SonarCloud Security Hotspot in SecurityConfig.java by replacing the ReDoS-vulnerable regex split with a safe comma split and trim loop.