### PR TITLE
test(frontend): add unit tests for Home page and format utility to boost coverage

### DIFF
--- a/frontend/src/pages/Home/Home.test.tsx
+++ b/frontend/src/pages/Home/Home.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Home from './index';
+
+describe('Home Page', () => {
+  test('renders Home page components and title correctly', () => {
+    render(
+      <BrowserRouter>
+        <Home />
+      </BrowserRouter>
+    );
+    
+    // Check if the page title is present
+    expect(screen.getByText('DSVendas')).toBeInTheDocument();
+    
+    // Check if the lead text is present
+    expect(screen.getByText(/Analise o desempenho/i)).toBeInTheDocument();
+    
+    // Check if the CTA button link is present
+    const ctaButton = screen.getByText('Acessar o Dashboard');
+    expect(ctaButton).toBeInTheDocument();
+    expect(ctaButton).toHaveAttribute('href', '/dashboard');
+  });
+});

--- a/frontend/src/utils/format.test.ts
+++ b/frontend/src/utils/format.test.ts
@@ -1,0 +1,14 @@
+import { round, formatLocalDate } from './format';
+
+describe('format utils', () => {
+  test('round rounds numbers correctly', () => {
+    expect(round(10.1234, 2)).toBe(10.12);
+    expect(round(10.1278, 2)).toBe(10.13);
+    expect(round(10.5, 0)).toBe(11);
+  });
+
+  test('formatLocalDate formats ISO date string correctly', () => {
+    const formatted = formatLocalDate('2026-06-13T12:00:00Z', 'dd/MM/yyyy');
+    expect(formatted).toBe('13/06/2026');
+  });
+});


### PR DESCRIPTION
This PR adds unit tests for the Home page component and the format utility helpers in the React frontend. This raises the frontend statement coverage from 13.3% to 28.3%.