### PR TITLE
config(sonar): exclude css styling files from code coverage metrics

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,8 +13,8 @@ sonar.exclusions=frontend/node_modules/**,frontend/build/**,**/target/**,fronten
 sonar.java.binaries=backend/target/classes
 sonar.coverage.jacoco.xmlReportPaths=backend/target/site/jacoco/jacoco.xml
 
-# Code coverage exclusions
-sonar.coverage.exclusions=backend/src/main/java/com/devsuperior/dsvendas/config/**,backend/src/main/java/com/devsuperior/dsvendas/dto/**,backend/src/main/java/com/devsuperior/dsvendas/entities/**,backend/src/main/java/com/devsuperior/dsvendas/DsvendasApplication.java,backend/src/main/java/com/devsuperior/dsvendas/ServletInitializer.java
+# Code coverage exclusions (excluding boilerplate java and non-testable CSS files)
+sonar.coverage.exclusions=backend/src/main/java/com/devsuperior/dsvendas/config/**,backend/src/main/java/com/devsuperior/dsvendas/dto/**,backend/src/main/java/com/devsuperior/dsvendas/entities/**,backend/src/main/java/com/devsuperior/dsvendas/DsvendasApplication.java,backend/src/main/java/com/devsuperior/dsvendas/ServletInitializer.java,**/*.css
 
 # JavaScript/TypeScript coverage report path
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info


### PR DESCRIPTION
This PR excludes CSS files from SonarCloud coverage metrics calculation using sonar.coverage.exclusions=**/*.css. This prevents untestable CSS lines of code from lowering the overall code coverage score.