### PR TITLE
config(ci): trigger build when sonar-project.properties changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
       - 'frontend/**'
       - '!frontend/**/*.md'
       - '.github/workflows/**'
+      - 'sonar-project.properties'
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - 'frontend/**'
       - '!frontend/**/*.md'
       - '.github/workflows/**'
+      - 'sonar-project.properties'
 
 jobs:
   build-and-test:


### PR DESCRIPTION
This PR adds sonar-project.properties to GHA paths triggers so that any updates to Sonar configurations automatically trigger the CI/CD pipeline.